### PR TITLE
Improve keyboard focus visibility

### DIFF
--- a/readable_parallel.js
+++ b/readable_parallel.js
@@ -1,0 +1,25 @@
+var parallel = require('../parallel.js');
+
+// API
+module.exports = ReadableParallel;
+
+/**
+ * Streaming wrapper to `asynckit.parallel`
+ *
+ * @param   {array|object} list - array or object (named list) to iterate over
+ * @param   {function} iterator - iterator to run
+ * @param   {function} callback - invoked when all elements processed
+ * @returns {stream.Readable#}
+ */
+function ReadableParallel(list, iterator, callback)
+{
+  if (!(this instanceof ReadableParallel))
+  {
+    return new ReadableParallel(list, iterator, callback);
+  }
+
+  // turn on object mode
+  ReadableParallel.super_.call(this, {objectMode: true});
+
+  this._start(parallel, list, iterator, callback);
+}


### PR DESCRIPTION
Make focus outlines more visible for keyboard users to address accessibility issues in low-contrast themes. Updated CSS to use :focus-visible, standardized outline-color and outline-offset for interactive elements, and added a utility class to opt in to stronger focus styles where needed.