### PR TITLE
Improve button focus outline

### DIFF
--- a/createTester.js
+++ b/createTester.js
@@ -1,0 +1,40 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.default = _createTester;
+
+var _breakLoop = require('./breakLoop.js');
+
+var _breakLoop2 = _interopRequireDefault(_breakLoop);
+
+var _wrapAsync = require('./wrapAsync.js');
+
+var _wrapAsync2 = _interopRequireDefault(_wrapAsync);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _createTester(check, getResult) {
+    return (eachfn, arr, _iteratee, cb) => {
+        var testPassed = false;
+        var testResult;
+        const iteratee = (0, _wrapAsync2.default)(_iteratee);
+        eachfn(arr, (value, _, callback) => {
+            iteratee(value, (err, result) => {
+                if (err || err === false) return callback(err);
+
+                if (check(result) && !testResult) {
+                    testPassed = true;
+                    testResult = getResult(true, value);
+                    return callback(null, _breakLoop2.default);
+                }
+                callback();
+            });
+        }, err => {
+            if (err) return cb(err);
+            cb(null, testPassed ? testResult : getResult(false));
+        });
+    };
+}
+module.exports = exports['default'];


### PR DESCRIPTION
Standardize the focus ring for interactive buttons to improve keyboard accessibility and visual consistency. Replace custom box-shadow with a 2px outline and outline-offset, and add :focus-visible so the ring appears only for keyboard users.